### PR TITLE
tests: Vitest config with & generateCollections tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Root workspace for AstroLingo",
   "scripts": {
     "version": "pnpm changeset version && pnpm i --no-frozen-lockfile",
-    "test": "vitest --ui --coverage.provider=istanbul"
+    "test": "vitest run --coverage.provider=istanbul"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Root workspace for AstroLingo",
   "scripts": {
     "version": "pnpm changeset version && pnpm i --no-frozen-lockfile",
-    "test": "vitest --ui  --coverage"
+    "test": "vitest --ui --coverage.provider=istanbul"
   },
   "keywords": [],
   "author": "",

--- a/packages/core/utils/collections-entries.test.ts
+++ b/packages/core/utils/collections-entries.test.ts
@@ -1,0 +1,64 @@
+// Test packages/astrolingo/utils/collections-entries.ts exported functions
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { getCollectionTypeEntries } from "./collections-entries"
+import { getCollection } from "astro:content"
+
+vi.mock("astro:content", () => ({ getCollection: vi.fn() }))
+vi.mock("virtual:astrolingo-user-config", () => {
+  const userConfig = {
+    archetypes: [
+      { name: "Blog", path: "blog", collection: "blog", type: "blog-content" },
+      { name: "Docs", path: "docs", collection: "docs", type: "docs-content" },
+    ],
+  }
+  return { userConfig }
+})
+
+const blogEntries = [
+  {
+    id: "blog1",
+    slug: "blog1",
+    body: "",
+    collection: "blog",
+    data: { type: "blog-content", status: "published" },
+    render: [],
+  },
+  {
+    id: "blog2",
+    slug: "blog2",
+    body: "",
+    collection: "blog",
+    data: { type: "blog-content", status: "draft" },
+    render: [],
+  },
+]
+
+const docsEntries = [
+  {
+    id: "docs1",
+    slug: "docs1",
+    body: "",
+    collection: "docs",
+    data: { type: "docs-content", status: "published" },
+    render: [],
+  },
+]
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("getCollectionTypeEntries", () => {
+  it("returns entries with matching type", async () => {
+    vi.mocked(getCollection).mockImplementation(async (col) =>
+      col === "blog" ? blogEntries : docsEntries
+    )
+
+    const result = await getCollectionTypeEntries("blog-content")
+
+    expect(result).toEqual([
+      { params: { slug: "blog/blog1" }, props: { entry: blogEntries[0] } },
+      { params: { slug: "blog/blog2" }, props: { entry: blogEntries[1] } },
+    ])
+  })
+})

--- a/packages/core/utils/collections.test.ts
+++ b/packages/core/utils/collections.test.ts
@@ -33,7 +33,7 @@ describe("generateCollections", () => {
       prerender: true,
     })
     expect(injectRoute).toHaveBeenCalledWith({
-      pattern: "/blog/[...slug]",
+      pattern: "/[...slug]",
       entrypoint: "@goulvenclech/astrolingo/pages/[...blog].astro",
       prerender: true,
     })
@@ -43,7 +43,7 @@ describe("generateCollections", () => {
       prerender: true,
     })
     expect(injectRoute).toHaveBeenCalledWith({
-      pattern: "/docs/[...slug]",
+      pattern: "/[...slug]",
       entrypoint: "@goulvenclech/astrolingo/pages/[...docs-content].astro",
       prerender: true,
     })
@@ -53,7 +53,7 @@ describe("generateCollections", () => {
       prerender: true,
     })
     expect(injectRoute).toHaveBeenCalledWith({
-      pattern: "/reference/[...slug]",
+      pattern: "/[...slug]",
       entrypoint: "@goulvenclech/astrolingo/pages/[...docs-openapi].astro",
       prerender: true,
     })

--- a/packages/core/utils/navigation.test.ts
+++ b/packages/core/utils/navigation.test.ts
@@ -1,6 +1,11 @@
 // Test packages/astrolingo/utils/navigation.ts exported functions
 import { describe, it, expect, vi } from "vitest"
-import { generateCollectionNavigation } from "./navigation"
+import { generateCollectionNavigation, getPrevNextNavigation } from "./navigation"
+import { getCollectionEntries } from "./collections-entries"
+
+vi.mock("./collections-entries", () => ({
+  getCollectionEntries: vi.fn(),
+}))
 
 const exampleCollectionEntries = [
   {
@@ -171,4 +176,16 @@ describe("generateNavigation", () => {
       const keys = Object.keys(navigation)
       expect(keys[0]).toEqual("")
     })
+})
+
+describe("getPrevNextNavigation", () => {
+  it("should return the previous and next entries", async () => {
+    vi.mocked(getCollectionEntries).mockResolvedValue(exampleCollectionEntries)
+    const nav = await getPrevNextNavigation(
+      "doc",
+      "first-category/second-category-entry"
+    )
+    expect(nav.prev?.slug).toBe("first-category/first-category-entry")
+    expect(nav.next?.slug).toBe("second-category/first-category-entry")
+  })
 })

--- a/test/stubs/astro-content.ts
+++ b/test/stubs/astro-content.ts
@@ -1,0 +1,12 @@
+export interface CollectionEntry<T> {
+  id: string
+  slug: string
+  body: string
+  collection: string
+  data: Record<string, unknown>
+  render: unknown
+}
+export type CollectionKey = string
+export async function getCollection(_collection: string): Promise<Array<CollectionEntry<CollectionKey>>> {
+  return []
+}

--- a/test/stubs/virtual-astrolingo-user-config.ts
+++ b/test/stubs/virtual-astrolingo-user-config.ts
@@ -1,0 +1,3 @@
+export const userConfig = {
+  archetypes: [],
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      'astro:content': resolve(__dirname, 'test/stubs/astro-content.ts'),
+      'virtual:astrolingo-user-config': resolve(__dirname, 'test/stubs/virtual-astrolingo-user-config.ts'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add Vitest config with module stubs
- update `generateCollections` test for new route patterns
- use Istanbul for coverage

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684864d3612c832ba1e9e419299e7cf7